### PR TITLE
UUID select bugfix

### DIFF
--- a/data/rx.playerdb/functions/admin/reset_all.mcfunction
+++ b/data/rx.playerdb/functions/admin/reset_all.mcfunction
@@ -21,3 +21,5 @@ data modify storage rx:io playerdb set value {}
 
 data modify storage rx:global playerdb.players set value []
 data modify storage rx:global playerdb.uuid set value []
+
+scoreboard players set @a rx.pdb.login 1

--- a/data/rx.playerdb/functions/impl/get_name.mcfunction
+++ b/data/rx.playerdb/functions/impl/get_name.mcfunction
@@ -8,4 +8,4 @@
 loot replace block -30000000 0 1602 container.0 loot rx:player_head
 
 #> copy to output
-data modify storage rx:temp playerdb.player_name set from block -30000000 0 1602 Items[-1].tag.SkullOwner.Name
+data modify storage rx:temp playerdb.player_name set from block -30000000 0 1602 Items[0].tag.SkullOwner.Name

--- a/data/rx.playerdb/functions/impl/update/uuid_search_bugfix.mcfunction
+++ b/data/rx.playerdb/functions/impl/update/uuid_search_bugfix.mcfunction
@@ -1,25 +1,14 @@
 # By: GrifterMage
-
 # 19 Apr 2021
-
-#
-
 #> Separate merged UUID database caused by bug in UUID Select
 
 # extract entries for input
-
 data modify storage rx:temp playerdb.uuid_db_update set value []
-
 execute if data storage rx:global playerdb.uuid[] run data modify storage rx:temp playerdb.uuid_db_update append from storage rx:global playerdb.uuid[].entries[]
 
 # purge existing database
-
 execute if data storage rx:global playerdb.uuid[] run data remove storage rx:global playerdb.uuid[]
 
 # iterate
-
 execute if data storage rx:temp playerdb.uuid_db_update[] run function rx.playerdb:impl/update/uuid_search_bugfix/_iter
-
-
-
-tellraw @a[tag=rx.admin] [{"text":"", "color":"gray"}, {"text":"P","color":"#dd9b14"},{"text":"l","color":"#df9412"},{"text":"a","color":"#e18e10"},{"text":"y","color":"#e3880e"},{"text":"e","color":"#e5810c"},{"text":"r","color":"#e77b0a"},{"text":"D","color":"#e97508"},{"text":"B","color":"#eb6f07"}, " UUID database reconstructed"]
+tellraw @a[tag=rx.admin] [{"text":"", "color":"gray"}, {"nbt": "playerdb.pretty_name", "storage": "rx:info", "interpret": true}, " UUID database reconstructed"]

--- a/data/rx.playerdb/functions/impl/update/uuid_search_bugfix.mcfunction
+++ b/data/rx.playerdb/functions/impl/update/uuid_search_bugfix.mcfunction
@@ -1,0 +1,25 @@
+# By: GrifterMage
+
+# 19 Apr 2021
+
+#
+
+#> Separate merged UUID database caused by bug in UUID Select
+
+# extract entries for input
+
+data modify storage rx:temp playerdb.uuid_db_update set value []
+
+execute if data storage rx:global playerdb.uuid[] run data modify storage rx:temp playerdb.uuid_db_update append from storage rx:global playerdb.uuid[].entries[]
+
+# purge existing database
+
+execute if data storage rx:global playerdb.uuid[] run data remove storage rx:global playerdb.uuid[]
+
+# iterate
+
+execute if data storage rx:temp playerdb.uuid_db_update[] run function rx.playerdb:impl/update/uuid_search_bugfix/_iter
+
+
+
+tellraw @a[tag=rx.admin] [{"text":"", "color":"gray"}, {"text":"P","color":"#dd9b14"},{"text":"l","color":"#df9412"},{"text":"a","color":"#e18e10"},{"text":"y","color":"#e3880e"},{"text":"e","color":"#e5810c"},{"text":"r","color":"#e77b0a"},{"text":"D","color":"#e97508"},{"text":"B","color":"#eb6f07"}, " UUID database reconstructed"]

--- a/data/rx.playerdb/functions/impl/update/uuid_search_bugfix/_iter.mcfunction
+++ b/data/rx.playerdb/functions/impl/update/uuid_search_bugfix/_iter.mcfunction
@@ -1,0 +1,45 @@
+# By: GrifterMage
+
+# 19 Apr 2021
+
+# 
+
+#> iterate
+
+#> Select appropriate entry, if any
+
+data modify storage rx:temp playerdb.UUID set from storage rx:temp playerdb.uuid_db_update[-1].UUID
+
+function rx.playerdb:impl/uuid/select
+
+
+
+#> If no element selected, create a new one
+
+execute store result score $selected rx.temp if data storage rx:global playerdb.uuid[{selected:1b}] 
+
+execute if score $selected rx.temp matches 0 run data modify storage rx:global playerdb.uuid append value {selected: 1b}
+
+execute if score $selected rx.temp matches 0 store result score $uid rx.temp run data get storage rx:temp playerdb.uuid_db_update[-1].UUID[0]
+
+execute if score $selected rx.temp matches 0 run data remove storage rx:temp playerdb.bits
+
+execute if score $selected rx.temp matches 0 run function rx.playerdb:impl/uid_to_bits
+
+execute if score $selected rx.temp matches 0 run data modify storage rx:global playerdb.uuid[-1].bits set from storage rx:temp playerdb.bits
+
+
+
+#> Store the current record into the selected position
+
+data modify storage rx:global playerdb.uuid[{selected:1b}].entries append from storage rx:temp playerdb.uuid_db_update[-1]
+
+data remove storage rx:temp playerdb.uuid_db_update[-1]
+
+
+
+# iterate
+
+execute unless data storage rx:temp playerdb.uuid_db_update[] run data remove storage rx:temp playerdb.uuid_db_update
+
+execute if data storage rx:temp playerdb.uuid_db_update[] run function rx.playerdb:impl/update/uuid_search_bugfix/_iter

--- a/data/rx.playerdb/functions/impl/update/uuid_search_bugfix/_iter.mcfunction
+++ b/data/rx.playerdb/functions/impl/update/uuid_search_bugfix/_iter.mcfunction
@@ -1,45 +1,24 @@
 # By: GrifterMage
-
 # 19 Apr 2021
-
 # 
-
 #> iterate
 
 #> Select appropriate entry, if any
-
 data modify storage rx:temp playerdb.UUID set from storage rx:temp playerdb.uuid_db_update[-1].UUID
-
 function rx.playerdb:impl/uuid/select
 
-
-
 #> If no element selected, create a new one
-
 execute store result score $selected rx.temp if data storage rx:global playerdb.uuid[{selected:1b}] 
-
 execute if score $selected rx.temp matches 0 run data modify storage rx:global playerdb.uuid append value {selected: 1b}
-
 execute if score $selected rx.temp matches 0 store result score $uid rx.temp run data get storage rx:temp playerdb.uuid_db_update[-1].UUID[0]
-
 execute if score $selected rx.temp matches 0 run data remove storage rx:temp playerdb.bits
-
 execute if score $selected rx.temp matches 0 run function rx.playerdb:impl/uid_to_bits
-
 execute if score $selected rx.temp matches 0 run data modify storage rx:global playerdb.uuid[-1].bits set from storage rx:temp playerdb.bits
 
-
-
 #> Store the current record into the selected position
-
 data modify storage rx:global playerdb.uuid[{selected:1b}].entries append from storage rx:temp playerdb.uuid_db_update[-1]
-
 data remove storage rx:temp playerdb.uuid_db_update[-1]
 
-
-
 # iterate
-
 execute unless data storage rx:temp playerdb.uuid_db_update[] run data remove storage rx:temp playerdb.uuid_db_update
-
 execute if data storage rx:temp playerdb.uuid_db_update[] run function rx.playerdb:impl/update/uuid_search_bugfix/_iter

--- a/data/rx.playerdb/functions/impl/uuid/new.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/new.mcfunction
@@ -12,6 +12,7 @@ execute if score $selected rx.temp matches 0 run scoreboard players operation $u
 execute if score $selected rx.temp matches 0 run function rx.playerdb:impl/uid_to_bits
 execute if score $selected rx.temp matches 0 run data modify storage rx:global playerdb.uuid append value {selected: 1b}
 execute if score $selected rx.temp matches 0 run data modify storage rx:global playerdb.uuid[-1].bits set from storage rx:temp playerdb.bits
+execute if score $selected rx.temp matches 0 store result storage rx:global playerdb.uuid[-1].bits.uuid0 int 1 run scoreboard players get @s rx.uuid0
 
 function rx.playerdb:impl/get_name
 

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit0/0_63
+
+function rx.playerdb:impl/select/bit0/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit1
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit1

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit0/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit1

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit0/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit0/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b0:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b0:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b0:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b0:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit1/0_63
+
+function rx.playerdb:impl/select/bit1/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit2
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit2

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit1/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit2

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit1/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit1/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b1:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b1:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b1:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b1:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit2/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit3

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit2/0_63
+
+function rx.playerdb:impl/select/bit2/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit3
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit3

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b2:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b2:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit2/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit2/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b2:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b2:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit3/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit4

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit3/0_63
+
+function rx.playerdb:impl/select/bit3/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit4
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit4

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit3/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit3/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b3:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b3:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b3:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b3:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit4/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit5

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit4/0_63
+
+function rx.playerdb:impl/select/bit4/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit5
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit5

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b4:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b4:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit4/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit4/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b4:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b4:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit5/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit6

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit5/0_63
+
+function rx.playerdb:impl/select/bit5/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit6
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit6

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b5:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b5:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit5/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit5/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b5:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b5:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+
+data modify storage rx:global playerdb.players[].bits.select set value 0b
+
 scoreboard players operation $bit rx.temp = $uid rx.temp
+
 scoreboard players operation $bit rx.temp %= $64 rx.int
+
 scoreboard players set $size rx.temp 0
-function rx.playerdb:impl/uuid/select/bit6/0_63
+
+function rx.playerdb:impl/select/bit6/0_63
+
 scoreboard players operation $uid rx.temp /= $64 rx.int
-execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit7
+
+execute if data storage rx:global playerdb.players[{bits:{select:0b}}] run data modify storage rx:global playerdb.players[{bits:{select:0b}}].selected set value 0b
+
+execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/select/bit7

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6.mcfunction
@@ -1,15 +1,9 @@
 # By: rx97
-
 data modify storage rx:global playerdb.uuid[].bits.select set value 0b
-
 scoreboard players operation $bit rx.temp = $uid rx.temp
-
 scoreboard players operation $bit rx.temp %= $64 rx.int
-
+scoreboard players set $size rx.temp 0
 function rx.playerdb:impl/uuid/select/bit6/0_63
-
 scoreboard players operation $uid rx.temp /= $64 rx.int
-
 execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b
-
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run function rx.playerdb:impl/uuid/select/bit7

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/0_7.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:0b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:0b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:1b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:1b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:2b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:2b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:3b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:3b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:4b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:4b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:5b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:5b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:6b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:6b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:7b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/0_7.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/0_7.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:0b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:1b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:2b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:3b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:4b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:5b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:6b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:7b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 0 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:0b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:0b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 1 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:1b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:1b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 2 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:2b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:2b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 3 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:3b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:3b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 4 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:4b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:4b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 5 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:5b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:5b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 6 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:6b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:6b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 7 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:7b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:7b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/16_23.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:16b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:16b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:17b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:17b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:18b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:18b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:19b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:19b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:20b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:20b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:21b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:21b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:22b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:22b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:23b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/16_23.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/16_23.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:16b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:17b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:18b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:19b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:20b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:21b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:22b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:23b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 16 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:16b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:16b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 17 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:17b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:17b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 18 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:18b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:18b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 19 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:19b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:19b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 20 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:20b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:20b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 21 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:21b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:21b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 22 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:22b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:22b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 23 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:23b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:23b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/24_31.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:24b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:24b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:25b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:25b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:26b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:26b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:27b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:27b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:28b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:28b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:29b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:29b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:30b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:30b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:31b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/24_31.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/24_31.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:24b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:25b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:26b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:27b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:28b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:29b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:30b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:31b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 24 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:24b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:24b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 25 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:25b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:25b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 26 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:26b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:26b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 27 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:27b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:27b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 28 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:28b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:28b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 29 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:29b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:29b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 30 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:30b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:30b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 31 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:31b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:31b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/32_39.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:32b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:33b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:34b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:35b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:36b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:37b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:38b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:39b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:32b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:32b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:33b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:33b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:34b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:34b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:35b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:35b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:36b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:36b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:37b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:37b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:38b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:38b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:39b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/32_39.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/32_39.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 32 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:32b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:32b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 33 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:33b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:33b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 34 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:34b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:34b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 35 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:35b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:35b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 36 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:36b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:36b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 37 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:37b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:37b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 38 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:38b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:38b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 39 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:39b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:39b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/40_47.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:40b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:41b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:42b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:43b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:44b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:45b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:46b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:47b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:40b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:40b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:41b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:41b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:42b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:42b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:43b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:43b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:44b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:44b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:45b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:45b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:46b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:46b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:47b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/40_47.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/40_47.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 40 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:40b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:40b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 41 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:41b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:41b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 42 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:42b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:42b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 43 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:43b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:43b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 44 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:44b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:44b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 45 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:45b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:45b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 46 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:46b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:46b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 47 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:47b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:47b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/48_55.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:48b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:48b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:49b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:49b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:50b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:50b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:51b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:51b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:52b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:52b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:53b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:53b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:54b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:54b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:55b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/48_55.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/48_55.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:48b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:49b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:50b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:51b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:52b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:53b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:54b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:55b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 48 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:48b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:48b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 49 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:49b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:49b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 50 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:50b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:50b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 51 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:51b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:51b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 52 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:52b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:52b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 53 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:53b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:53b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 54 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:54b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:54b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 55 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:55b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:55b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/56_63.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:56b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:57b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:58b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:59b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:60b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:61b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:62b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:63b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:56b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:56b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:57b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:57b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:58b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:58b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:59b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:59b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:60b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:60b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:61b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:61b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:62b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:62b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:63b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/56_63.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/56_63.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 56 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:56b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:56b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 57 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:57b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:57b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 58 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:58b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:58b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 59 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:59b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:59b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 60 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:60b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:60b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 61 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:61b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:61b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 62 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:62b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:62b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 63 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:63b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:63b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/8_15.mcfunction
@@ -1,17 +1,9 @@
 # By: rx97
-
 execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:8b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:8b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:9b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:9b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:10b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:10b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:11b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:11b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:12b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:12b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:13b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:13b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:14b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:14b}}].bits.select set value 1b
-
 execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:15b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/bit6/8_15.mcfunction
+++ b/data/rx.playerdb/functions/impl/uuid/select/bit6/8_15.mcfunction
@@ -1,9 +1,17 @@
 # By: rx97
-execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:8b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:9b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:10b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:11b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:12b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:13b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:14b}}].bits.select set value 1b
-execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.uuid[{selected:1b, bits:{b6:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b6:15b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 8 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:8b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:8b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 9 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:9b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:9b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 10 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:10b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:10b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 11 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:11b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:11b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 12 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:12b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:12b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 13 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:13b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:13b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 14 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:14b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:14b}}].bits.select set value 1b
+
+execute if score $bit rx.temp matches 15 if data storage rx:global playerdb.players[{selected:1b, bits:{b6:15b}}] store result score $size rx.temp run data modify storage rx:global playerdb.players[{selected:1b, bits:{b6:15b}}].bits.select set value 1b

--- a/data/rx.playerdb/functions/impl/uuid/select/generate.py
+++ b/data/rx.playerdb/functions/impl/uuid/select/generate.py
@@ -16,7 +16,7 @@ ITERATIONS = math.log(MAX_INT, BASE) + 1
 TREE = 'execute if score $bit rx.temp matches {low}..{high} run function rx.playerdb:impl/uuid/select/bit{num}/{low}_{high}'  # noqa: E501
 
 LEAF = (
-    'execute if score $bit rx.temp matches @ if data storage rx:global playerdb.uuid[{selected:1b, bits:{b%:@b}}] store result score $size rx.temp run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b%:@b}}].bits.select set value 1b'  # noqa: E501
+    'execute if score $bit rx.temp matches @ if data storage rx:global playerdb.uuid[{selected:1b, bits:{b%:@b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b%:@b}}].bits.select set value 1b'  # noqa: E501
 )
 
 
@@ -40,7 +40,7 @@ def gen_bit(bit_num):
         f'function rx.playerdb:impl/uuid/select/bit{bit_num}/0_{BASE-1}\n'
         f'scoreboard players operation $uid rx.temp /= ${BASE} rx.int\n'
         'execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b\n'  # noqa
-        f'execute if score $size rx.temp matches 2.. run function rx.playerdb:impl/uuid/select/bit{bit_num+1}\n'  # noqa: E501
+        f'execute if data storage rx:global playerdb.uuid[{{selected:1b}}] run function rx.playerdb:impl/uuid/select/bit{bit_num+1}\n'  # noqa: E501
     )
     fname = Path(f'bit{bit_num}.mcfunction')
     make_file(fname, bit)

--- a/data/rx.playerdb/functions/init.mcfunction
+++ b/data/rx.playerdb/functions/init.mcfunction
@@ -9,10 +9,10 @@
 #> LL Load + version
 scoreboard players set rx.PlayerDB load 1
 
-data modify storage rx:info playerdb.version set value {major: 1, minor: 0, patch: 3}
+data modify storage rx:info playerdb.version set value {major: 1, minor: 1, patch: 0}
 scoreboard players set rx.pdb.major load 1
-scoreboard players set rx.pdb.minor load 0
-scoreboard players set rx.pdb.patch load 3
+scoreboard players set rx.pdb.minor load 1
+scoreboard players set rx.pdb.patch load 0
 
 data modify storage rx:info playerdb.pretty_version set value '[{"storage": "rx:info", "nbt": "playerdb.version.major"}, ".", {"storage": "rx:info", "nbt": "playerdb.version.minor"}, ".", {"storage": "rx:info", "nbt": "playerdb.version.patch"}]'
 

--- a/data/rx.playerdb/functions/shulker_init.mcfunction
+++ b/data/rx.playerdb/functions/shulker_init.mcfunction
@@ -7,7 +7,7 @@
 data modify storage rx:info playerdb.name set value 'PlayerDB'
 data modify storage rx:info playerdb.pretty_name set value '[{"text":"P","color":"#dd9b14"},{"text":"l","color":"#df9412"},{"text":"a","color":"#e18e10"},{"text":"y","color":"#e3880e"},{"text":"e","color":"#e5810c"},{"text":"r","color":"#e77b0a"},{"text":"D","color":"#e97508"},{"text":"B","color":"#eb6f07"}]'
 
-data modify storage rx:info playerdb.version set value {major: 1, minor: 0, patch: 3}
+data modify storage rx:info playerdb.version set value {major: 1, minor: 1, patch: 0}
 data modify storage rx:info playerdb.pretty_version set value '[{"storage": "rx:info", "nbt": "playerdb.version.major"}, ".", {"storage": "rx:info", "nbt": "playerdb.version.minor"}, ".", {"storage": "rx:info", "nbt": "playerdb.version.patch"}]'
 
 scoreboard objectives add rx.io dummy


### PR DESCRIPTION
Alters Select so it continues checking bits of UUID[0] until either no matches remain or the last bit is checked.

Removed references to $size rx.temp since it doesn't need to know exactly how many entries are potential matches--it needs to keep checking until there are either no matches or it's checked all bits.

Also added an update function to separate the existing UUID DB entries into the correct positions, but left it as /impl/ because I don't know how you'd prefer to tie something like that in.