### PR TITLE
Embed the function tree inside the select implementation

### DIFF
--- a/src/uuid.md
+++ b/src/uuid.md
@@ -20,6 +20,39 @@ execute if data storage rx:global playerdb.uuid[] run sequentially
 	data modify storage rx:global playerdb.uuid[].selected set value 1b
 	function ./tree/bit0
 
+#!for i in range(6)
+#!function generate_path("uuid/tree/bit" ~ i)
+
+data modify storage rx:global playerdb.uuid[].bits.select set value 0b
+scoreboard players operation $bit rx.temp = $uid rx.temp
+scoreboard players operation $bit rx.temp %= $64 rx.int
+scoreboard players set $size rx.temp 0
+
+#!for node in generate_tree(render_path, range(64))
+#!function node.parent append
+#!if node.partition(8)
+execute if score $bit rx.temp matches {{ node.range }} run function {{ node.children }}
+#!else
+#!set path = "playerdb.uuid[{selected:1b, bits:{b" ~ i ~ ":" ~ node.value ~ "b}}]"
+execute
+    if score $bit rx.temp matches {{ node.range }}
+    if data storage rx:global {{ path }} run data modify storage rx:global {{ path }}.bits.select set value 1b
+#!endif
+#!endfunction
+#!endfor
+
+execute
+    if data storage rx:global playerdb.uuid[{bits: {select: 0b}}]
+    run data modify storage rx:global playerdb.uuid[{bits: {select: 0b}}].selected set value 0b
+
+#!if not loop.last
+scoreboard players operation $uid rx.temp /= 64 rx.int
+execute if data storage rx:global playerdb.uuid[{selected:1b}] run function ./bit{{ i + 1 }}
+#!endif
+
+#!endfunction
+#!endfor
+
 #> selected or not
 execute if data storage rx:global playerdb.uuid[{selected:1b}] run sequentially
 	execute store result score $loop rx.temp
@@ -295,86 +328,6 @@ execute if score $found rx.temp matches 0 run sequentially
 
 #> else: update! we have a name change!!
 execute if score $found rx.temp matches 1 run function ./update
-```
-
-</details>
-
-## uuid/tree
-
-<details>
-
-```python
-# @plugin
-
-from beet import Function, Context
-import math
-
-
-COMMENT = "# By: rx97\n"
-
-BASE = 64
-BRANCHES = 8
-MAX_INT = 2 ** 31 - 1
-
-ITERATIONS = math.log(MAX_INT, BASE) + 1
-
-
-TREE = "execute if score $bit rx.temp matches {low}..{high} run function ./bit{num}/{low}_{high}"  # noqa: E501
-LEAF = "execute if score $bit rx.temp matches @ if data storage rx:global playerdb.uuid[{selected:1b, bits:{b%:@b}}] run data modify storage rx:global playerdb.uuid[{selected:1b, bits:{b%:@b}}].bits.select set value 1b"  # noqa: E501
-
-
-def gen_bit(ctx: Context, bit_num):
-    bit = (
-        "data modify storage rx:global playerdb.uuid[].bits.select set value 0b\n"
-        "scoreboard players operation $bit rx.temp = $uid rx.temp\n"
-        f"scoreboard players operation $bit rx.temp %= ${BASE} rx.int\n"
-        "scoreboard players set $size rx.temp 0\n"
-        f"function ./bit{bit_num}/0_{BASE-1}\n"
-        f"scoreboard players operation $uid rx.temp /= ${BASE} rx.int\n"
-        "execute if data storage rx:global playerdb.uuid[{bits:{select:0b}}] run data modify storage rx:global playerdb.uuid[{bits:{select:0b}}].selected set value 0b\n"  # noqa
-        f"execute if data storage rx:global playerdb.uuid[{{selected:1b}}] run function ./bit{bit_num+1}\n"  # noqa: E501
-    )
-    ctx.generate(f"uuid/tree/bit{bit_num}", Function(bit))
-
-
-def gen_tree(ctx: Context, bit_num, low, high):
-    change = (high - low) // BRANCHES
-
-    low_values = [low + change * i for i in range(BRANCHES)]
-    high_values = [(low + change * (i + 1)) for i in range(BRANCHES)]
-
-    # print(low_values)
-    # print(high_values)
-
-    values = list(zip(low_values, high_values))
-
-    if low + BRANCHES < high:
-        tree = tuple(
-            TREE.format(low=value[0], high=value[1] - 1, num=bit_num)
-            for value in values
-        )
-
-        ctx.generate(f"uuid/tree/bit{bit_num}/{low}_{high-1}", Function(tree))
-
-        for value in values:
-            gen_tree(ctx, bit_num, value[0], value[1])
-
-    else:
-        leaf = tuple(
-            LEAF.replace("@", str(low + i)).replace("%", str(bit_num))
-            for i in range(BRANCHES)
-        )
-        ctx.generate(f"uuid/tree/bit{bit_num}/{low}_{low+BRANCHES-1}", Function(leaf))
-
-
-def main(ctx: Context):
-    for i in range(int(ITERATIONS) + 1):
-        gen_bit(ctx, i)
-        gen_tree(ctx, i, 0, BASE)
-
-
-main(ctx)
-
 ```
 
 </details>


### PR DESCRIPTION
I wanted to try and implement the bit checks using the tree generator provided by beet. I haven't tested it in-game yet but the resulting functions seem equivalent. The only difference is that beet generates the root of the tree outside of the subdirectory, so each `uuid/tree/bitX` function includes the root layer of the function tree.

There was a off-by-one error that caused the previous generator to generate code for an extra unnecessary bit, and potentially making the worst-case 15% slower. It also used to generate a call to the next bit even for the last bit.

I ended up using Jinja directly to generate each function tree so I removed the inline plugin at the end of the file.

Let me know what you think.